### PR TITLE
Change default host to ..io

### DIFF
--- a/pyphoton/client.py
+++ b/pyphoton/client.py
@@ -9,7 +9,7 @@ class Photon:
 
     def __init__(
             self,
-            host='https://photon.komoot.de',
+            host='https://photon.komoot.io',
             language='en'
     ):
         self._host = host.strip('/')


### PR DESCRIPTION
Photon changed their public use domain to .io (from .de) so this should be changed as the default :)